### PR TITLE
Bugfix and UTF 8 output for the Textile Convertor

### DIFF
--- a/lib/StaticVolt/Convertor/Textile.pm
+++ b/lib/StaticVolt/Convertor/Textile.pm
@@ -1,6 +1,9 @@
 # ABSTRACT: StaticVolt convertor for textile
 
 package StaticVolt::Convertor::Textile;
+{
+  $StaticVolt::Convertor::Textile::VERSION = '1.00';
+}
 
 use strict;
 use warnings;
@@ -11,7 +14,10 @@ use Text::Textile qw( textile );
 
 sub convert {
     my $content = shift;
-    return textile $content;
+    my $textile=Text::Textile->new();
+	$textile->charset('utf-8');
+	my $html_content = $textile->process($content);
+    return $html_content;
 }
 
 __PACKAGE__->register(qw/ textile /);
@@ -20,6 +26,16 @@ __PACKAGE__->register(qw/ textile /);
 
 __END__
 
+=pod
+
+=head1 NAME
+
+StaticVolt::Convertor::Textile - StaticVolt convertor for textile
+
+=head1 VERSION
+
+version 1.00
+
 =head1 Registered Extensions
 
 =over 4
@@ -27,3 +43,17 @@ __END__
 =item * C<textile>
 
 =back
+
+=head1 AUTHOR
+
+Alan Haggai Alavi <haggai@cpan.org>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is Copyright (c) 2013 by Alan Haggai Alavi.
+
+This is free software, licensed under:
+
+  The Artistic License 2.0 (GPL Compatible)
+
+=cut


### PR DESCRIPTION
Dear Mr. Haggai,

I wanted to say thank you for your great module StaticVolt! It is really a awesome piece of software and I learned so much alone through reading your code.
I have written a Gtk3 GUI ( at the moment only with support for textile and not published on github), which is based on your module. Doing this I noticed some "bugs":

1) If you create the StaticVolt with different absolute layout, includes etc. directories and therefore start $stratovolt->compile from a different cwd than the directory which contains _includes, _layouts etc, compiling doesn't work
[for example in the perl script the code is:

> ```
>  my $projectdir = $siteobject->{'dir'};
> ```
> 
>   my $staticvolt = StaticVolt->new(
>       'includes'  =>  "$projectdir/_includes",
>       'layouts'   =>  "$projectdir/_layouts",
>       'source'    =>  "$projectdir/_source",
>       'destination'   => "$projectdir/_site",
>   );
> 
>   $staticvolt->compile;
> 
> whereas the $projectdir is something like /home/$user/Dokumente/www-example-de

2) Note: If projectdir is /home/$user/Dokumente/www.example.de. I will try to find a solution for this, too. But at the moment I didn't solve this..

3) For my application, it would be good if textile converts the source files with charset "utf-8"

Again thank you very much for your wonderful program.

Best regards,
Max
